### PR TITLE
feat: Introduce a pre-configured Axios instance with authentication a…

### DIFF
--- a/src/utils/axiosInstance.ts
+++ b/src/utils/axiosInstance.ts
@@ -1,0 +1,35 @@
+import axios, { AxiosInstance, InternalAxiosRequestConfig, AxiosError } from 'axios';
+
+const axiosInstance: AxiosInstance = axios.create({
+  baseURL: 'http://localhost:8080/api', 
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+axiosInstance.interceptors.request.use(
+  (config: InternalAxiosRequestConfig) => {
+    const token = localStorage.getItem('auth_token');
+    
+    if (token) {
+      config.headers['Authorization'] = `Bearer ${token}`; 
+    }
+    
+    return config;
+  },
+  (error: AxiosError) => {
+    return Promise.reject(error);
+  }
+);
+
+axiosInstance.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  (error: AxiosError) => {
+    console.error('API Error:', error);
+    return Promise.reject(error);
+  }
+);
+
+export default axiosInstance;

--- a/src/utils/axiosInstance.tsx
+++ b/src/utils/axiosInstance.tsx
@@ -1,8 +1,0 @@
-import axios from 'axios';
-
-// @ts-ignore
-const axiosInstance = axios.create({
-  baseURL: 'http://localhost:8080/api',
-});
-
-export default axiosInstance;


### PR DESCRIPTION
This pull request refactors how the Axios HTTP client is set up and used in the codebase. The main improvement is the creation of a new `axiosInstance` utility with built-in support for JSON headers, automatic authorization token injection, and error handling. The old, simpler implementation is removed.

**HTTP client improvements:**

* Introduced a new `axiosInstance` in `src/utils/axiosInstance.ts` that sets a default `Content-Type` header, injects an `Authorization` header with a bearer token from local storage if available, and adds request/response interceptors for better error handling and debugging.

**Code cleanup:**

* Removed the old, basic Axios instance setup from `src/utils/axiosInstance.tsx` in favor of the new, enhanced implementation.